### PR TITLE
Properly end stream when there are no errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ module.exports = function(options) {
       compareJson(filePathCache, opts);
       if (failed) {
         cb(new gutil.PluginError('gulp-compare-json', 'Comparing json files failed', {showStack: false}));
+      } else {
+        cb(null);
       }
     } catch (err) {
       cb(new gutil.PluginError('gulp-compare-json', err, {showStack: true}));


### PR DESCRIPTION
Fixes #3.

This PR solves the issue for me. I do not know if there are better arguments for `cb` than just `null`.